### PR TITLE
fix: Remove bufsize argument from subprocess.Popen

### DIFF
--- a/packtivity/handlers/execution_handlers.py
+++ b/packtivity/handlers/execution_handlers.py
@@ -310,7 +310,6 @@ def execute_and_tail_subprocess(
                     stdin=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     stdout=subprocess.PIPE,
-                    bufsize=1,
                     close_fds=True,
                 )
                 proc.stdin.write(stdin_content.encode("utf-8"))
@@ -320,7 +319,6 @@ def execute_and_tail_subprocess(
                     shlex.split(command_string),
                     stderr=subprocess.STDOUT,
                     stdout=subprocess.PIPE,
-                    bufsize=1,
                     close_fds=True,
                 )
 


### PR DESCRIPTION
Resolves #77 

Running

```console
pydoc subprocess.Popen
```

shows

```
subprocess.Popen(args, bufsize=-1, ...
```

As "line buffering (buffering=1) isn't supported in binary mode", then remove the line buffering by removing the `bufsize` and letting it default to `-1`.

c.f. https://docs.python.org/3/library/subprocess.html#subprocess.Popen especially

> bufsize will be supplied as the corresponding argument to the [`open()`](https://docs.python.org/3/library/functions.html#open) function when creating the stdin/stdout/stderr pipe file objects:
> 
> * 0 means unbuffered (read and write are one system call and can return short)
> * 1 means line buffered (only usable if `universal_newlines=True` i.e., in a text mode)
> * any other positive value means use a buffer of approximately that size
> * negative bufsize (the default) means the system default of io.DEFAULT_BUFFER_SIZE will be used.

@lukasheinrich The use of `bufsize=1` was added all the way back in 2017 in  https://github.com/yadage/packtivity/commit/3c309d44e76d92714989f810dbf2a5277950348d, so you might have a very good reason for needing that. If you can elaborate that would be great.