### PR TITLE
ci: Update publishing workflow to use build and run on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,13 @@ name: CI/CD
 
 on:
   push:
+    branches:
+    - master
   pull_request:
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
     - master
+  workflow_dispatch:
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,43 +14,53 @@ jobs:
   build-and-publish:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Checkout
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
-    - name: Install pep517 and twine
+        python-version: '3.10'
+
+    - name: Install build, check-manifest, and twine
       run: |
-        python -m pip install pep517 --user
-        python -m pip install twine
-    - name: Build a binary wheel and a source tarball
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build check-manifest twine
+        python -m pip list
+
+    - name: Check MANIFEST
       run: |
-        python -m pep517.build --source --binary --out-dir dist/ .
-    - name: Verify tagged commits don't have dev versions
-      if: startsWith(github.ref, 'refs/tags')
+        check-manifest
+
+    - name: Build a sdist and a wheel
       run: |
-        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
-          echo "this is incorrrectly being treated as a dev release"
-          echo "intentionally erroring with 'return 1' now"
-          return 1
-        fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        python -m build .
+
     - name: Verify the distribution
       run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/packtivity-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/packtivity-*.whl
+
     - name: Publish distribution 📦 to Test PyPI
-      # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'yadage/packtivity'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      # publish to TestPyPI on tag events
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/packtivity'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'yadage/packtivity'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      # publish to PyPI on releases
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/packtivity'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 yadage developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+prune **
+graft packtivity
+graft tests
+
+include setup.py
+include LICENSE
+include README.md
+include MANIFEST.in
+
+global-exclude __pycache__ *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ setup(
     author="Lukas Heinrich",
     author_email="lukas.heinrich@cern.ch",
     packages=find_packages(),
+    # Support Python 3.6+ but keep legacy support for Python 2.7 until 2022
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     include_package_data=True,
     install_requires=deps,
-    extras_require={"celery": ["celery", "redis"],},
+    extras_require={"celery": ["celery", "redis"]},
     entry_points={
         "console_scripts": [
             "packtivity-run=packtivity.cli:runcli",
@@ -40,4 +42,19 @@ setup(
         ],
     },
     dependency_links=[],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Operating System :: OS Independent",
+    ],
 )


### PR DESCRIPTION
```
* Add MIT License
* Add MANIFEST.in
* Add python_requires to setup.py to require Python 2.7 or Python 3.6+
* Add PyPI metadata classifiers to setup.py
* Add workflow dispatch to CI
* Update publishing workflow to use the build package to build an sdist
and a wheel
* Publish to TestPyPI on tags and publish to PyPI on GitHub releases
```