### PR TITLE
ci: Enable deployment to PyPI on GitHub release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
     - master
-  workflow_dispatch:
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - master
   workflow_dispatch:
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
```
* Add GitHub release publication events to triggers for package
publishing workflow.
   - This is a fix that will enable deploying to PyPI through creation
     of GitHub releases.
   - Amends PR #79
```