### PR TITLE
ci: Remove deprecated Pythons from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == '3.10'
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
         tags: ${{ github.sha }}
         load: true
         push: false
-        platforms: linux/amd64,linux/arm64
 
     - name: List built images
       run: docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -59,12 +59,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build Docker image
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,14 +101,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build Docker image
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Test build
+      id: docker_build_test
+      uses: docker/build-push-action@v4
       with:
-        repository: yadage/packtivity
-        dockerfile: Dockerfile
-        tag_with_sha: true
-        tag_with_ref: true
+        context: .
+        file: Dockerfile
+        tags: ${{ github.sha }}
+        load: true
         push: false
+        platforms: linux/amd64,linux/arm64
+
     - name: List built images
       run: docker images

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,22 +14,59 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build and Publish to Registry
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: yadage/packtivity
-        dockerfile: Dockerfile
-        tags: latest
-    - name: Build and Publish to Registry with Release Tag
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v1
+
+    - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: yadage/packtivity
-        dockerfile: Dockerfile
-        tags: latest,latest-stable
-        tag_with_ref: true
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish to registry
+        # every PR will trigger a push event on main, so check the push event is actually coming from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'yadage/packtivity'
+        id: docker_build_latest
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          tags: |
+            ${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and publish to registry with release tag
+        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/packtivity'
+        id: docker_build_release
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:latest-stable
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:latest-stable
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,37 +36,37 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and publish to registry
-        # every PR will trigger a push event on main, so check the push event is actually coming from main
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'yadage/packtivity'
-        id: docker_build_latest
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile
-          tags: |
-            ${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:latest
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
-          push: true
-          platforms: linux/amd64,linux/arm64
+    - name: Build and publish to registry
+      # every PR will trigger a push event on main, so check the push event is actually coming from main
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'yadage/packtivity'
+      id: docker_build_latest
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: Dockerfile
+        tags: |
+          ${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:latest
+        labels: |
+          org.opencontainers.image.source=${{ github.event.repository.html_url }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        push: true
+        platforms: linux/amd64,linux/arm64
 
-      - name: Build and publish to registry with release tag
-        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/packtivity'
-        id: docker_build_release
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: Dockerfile
-          tags: |
-            ${{ github.repository }}:latest
-            ${{ github.repository }}:latest-stable
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:latest-stable
-          labels: |
-            org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.revision=${{ github.sha }}
-          push: true
-          platforms: linux/amd64,linux/arm64
+    - name: Build and publish to registry with release tag
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/packtivity'
+      id: docker_build_release
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: Dockerfile
+        tags: |
+          ${{ github.repository }}:latest
+          ${{ github.repository }}:latest-stable
+          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:latest-stable
+        labels: |
+          org.opencontainers.image.source=${{ github.event.repository.html_url }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        push: true
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -26,7 +26,7 @@ jobs:
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: ${{ secrets.DOCKER_TOKEN }}
 
     - name: Login to GitHub Container Registry
       if: github.event_name != 'pull_request'

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -55,14 +55,16 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # publish to TestPyPI on tag events
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/packtivity'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+        print_hash: true
 
     - name: Publish distribution 📦 to PyPI
       # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/packtivity'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         password: ${{ secrets.pypi_password }}
+        print_hash: true


### PR DESCRIPTION
```
* Update GitHub Actions to latest releases.
* Remove deprecated Pythons (3.6) from testing matrix.
* Update Docker build workflows.
```