### PR TITLE
fix: Update Dockerfile base to almalinux:9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM centos:8
-RUN dnf install -y python3
+FROM almalinux:9.1
+
 COPY . /packtivity
 WORKDIR /packtivity
-RUN dnf install -y python3-pip
-RUN pip3 install -e .
+
+# Set PATH to pickup virtualenv by default
+ENV PATH=/usr/local/venv/bin:"${PATH}"
+RUN dnf install -y \
+        python3 \
+        python3-pip \
+    python3 -m venv /usr/local/venv && \
+    . /usr/local/venv/bin/activate && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
+    python -m pip --no-cache-dir install . && \
+    python -m pip list

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /packtivity
 ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN dnf install -y \
         python3 \
-        python3-pip \
+        python3-pip && \
     python3 -m venv /usr/local/venv && \
     . /usr/local/venv/bin/activate && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \


### PR DESCRIPTION
centos:8 is now dead, so use almalinux:9.1 as CERN is adopting AlmaLinux