### PR TITLE
fix: Add importlib-metadata constraint to avoid celery import bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": [
-            "celery",
+            "celery>=4.0.0; python_version >= '3.8'",
+            "celery<=4.2.2; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
             "redis",
-            "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": [
-            "celery==4.2.2",
+            "celery>=5.0.0",
             "redis",
             "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,13 @@ setup(
     python_requires=">=3.7",
     include_package_data=True,
     install_requires=deps,
-    extras_require={"celery": ["celery", "redis"]},
+    extras_require={
+        "celery": [
+            "celery",
+            "redis",
+            "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
+        ]
+    },
     entry_points={
         "console_scripts": [
             "packtivity-run=packtivity.cli:runcli",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": [
-            "celery",
+            "celery>=4.2.2",
             "redis",
             "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": [
-            "celery>=4.0.0; python_version >= '3.8'",
-            "celery<=4.2.2; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
+            "celery",
             "redis",
+            "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": [
-            "celery>=4.2.2",
+            "celery==4.2.2",
             "redis",
             "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]


### PR DESCRIPTION
Resolves #89

* Fix requires a new release of kombu
   - c.f. https://github.com/celery/celery/issues/7783#issuecomment-1283638046
* This should be viewed as temporary. As soon as there is a new release of kombu the release with this fix in in should get yanked in favor of a new release without this restriction.
* Add lower bound of celery>=5.0.0.

```
* Fix requires a new release of kombu
   - c.f. https://github.com/celery/celery/issues/7783#issuecomment-1283638046
   - This should be viewed as temporary. As soon as there is a new release of kombu
     the release with this fix in in should get yanked in favor of a new release
     without this restriction.
* Add lower bound of celery>=5.0.0.
```