### PR TITLE
build: Require Python 3.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -32,14 +32,13 @@ setup(
     author="Lukas Heinrich",
     author_email="lukas.heinrich@cern.ch",
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     install_requires=deps,
     extras_require={
         "celery": [
             "celery>=5.0.0",
             "redis",
-            "importlib-metadata<5.0.0; python_version < '3.8'",  # FIXME: c.f. https://github.com/celery/celery/issues/7783
         ]
     },
     entry_points={
@@ -57,7 +56,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Resolves #91

* Python 3.7 is EOL on 2023-06-27 so only support Pythons with support from the PSF.

```
$ eol python
┌───────┬────────────┬─────────┬────────────────┬────────────┐
│ cycle │  release   │ latest  │ latest release │    eol     │
├───────┼────────────┼─────────┼────────────────┼────────────┤
│ 3.11  │ 2022-10-24 │ 3.11.4  │   2023-06-06   │ 2027-10-24 │
│ 3.10  │ 2021-10-04 │ 3.10.12 │   2023-06-06   │ 2026-10-04 │
│ 3.9   │ 2020-10-05 │ 3.9.17  │   2023-06-06   │ 2025-10-05 │
│ 3.8   │ 2019-10-14 │ 3.8.17  │   2023-06-06   │ 2024-10-14 │
│ 3.7   │ 2018-06-26 │ 3.7.17  │   2023-06-05   │ 2023-06-27 │
│ 3.6   │ 2016-12-22 │ 3.6.15  │   2021-09-03   │ 2021-12-23 │
│ 3.5   │ 2015-09-12 │ 3.5.10  │   2020-09-05   │ 2020-09-13 │
│ 3.4   │ 2014-03-15 │ 3.4.10  │   2019-03-18   │ 2019-03-18 │
│ 3.3   │ 2012-09-29 │ 3.3.7   │   2017-09-19   │ 2017-09-29 │
│ 2.7   │ 2010-07-03 │ 2.7.18  │   2020-04-19   │ 2020-01-01 │
│ 2.6   │ 2008-10-01 │ 2.6.9   │   2013-10-29   │ 2013-10-29 │
└───────┴────────────┴─────────┴────────────────┴────────────┘
```