### PR TITLE
build: Restrict jq to jqlang pre v1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = [
     "glob2",
     "jsonpointer",
     "jsonpath-rw",
-    "jq",
+    "jq>=1.0.0,<1.6.0",  # FIXME c.f. https://github.com/yadage/packtivity/issues/96
     "yadage-schemas",
     "mock",
     "checksumdir",


### PR DESCRIPTION
In relation to Issue #96 

Place an upper limit on jq of '<1.6.0' as jq (the Python library) v1.6.x+ are compatible with jq (the language) v1.7+ and packtivity is currently compatible with jq (the language) v1.6.
   - This should be viewed as a temporary stopgap measure to avoid large yadage ecosystem breakage and should be reverted as soon as a workaround is found.

```
* Place an upper limit on jq of '<1.6.0' as jq (the Python library)
  v1.6.x+ are compatible with jq (the language) v1.7+ and packtivity
  is currently compatible with jq (the language) v1.6.
   - This should be viewed as a temporary stopgap measure to avoid large
     yadage ecosystem breakage and should be reverted as soon as a
     workaround is found.
   - c.f. https://github.com/yadage/packtivity/issues/96
```