### PR TITLE
fix: Use 'paths(scalars)' as 'leaf_paths' filter is deprecated 

### DIFF
--- a/packtivity/datamodels/purejson.py
+++ b/packtivity/datamodels/purejson.py
@@ -50,7 +50,7 @@ class PureJsonModel(object):
         else:
             ptrs = [
                 jsonpointer.JsonPointer.from_parts(parts)
-                for parts in self.jq("leaf_paths", multiple_output=True).typed()
+                for parts in self.jq("paths(scalars)", multiple_output=True).typed()
             ]
             for p in ptrs:
                 yield p, p.get(self.typed())

--- a/packtivity/typedleafs.py
+++ b/packtivity/typedleafs.py
@@ -215,7 +215,7 @@ class TypedLeafs(object):
         else:
             ptrs = [
                 jsonpointer.JsonPointer.from_parts(parts)
-                for parts in self.jq("leaf_paths", multiple_output=True).typed()
+                for parts in self.jq("paths(scalars)", multiple_output=True).typed()
             ]
             for p in ptrs:
                 yield p, p.get(self.typed())

--- a/packtivity/utils.py
+++ b/packtivity/utils.py
@@ -32,7 +32,7 @@ def leaf_iterator(jsonable):
     if not isinstance(jsonable, (list, dict)):
         yield jsonpointer.JsonPointer(""), jsonable
     else:
-        allleafs = jq.jq("leaf_paths").transform(jsonable, multiple_output=True)
+        allleafs = jq.jq("paths(scalars)").transform(jsonable, multiple_output=True)
         leafpointers = [jsonpointer.JsonPointer.from_parts(x) for x in allleafs]
         for x in leafpointers:
             yield x, x.get(jsonable)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = [
     "glob2",
     "jsonpointer",
     "jsonpath-rw",
-    "jq>=1.0.0,<1.6.0",  # FIXME c.f. https://github.com/yadage/packtivity/issues/96
+    "jq>=1.0.0",
     "yadage-schemas",
     "mock",
     "checksumdir",


### PR DESCRIPTION
Part of Issue #96 

The 'leaf_paths' filter has been deprecated for 9 years and was removed in jqlang v1.7 (jq v1.6) so use the 'paths(scalars)' filter.
   - c.f. https://github.com/jqlang/jq/pull/2666
   - c.f. https://github.com/jqlang/jq/pull/426


```
* The 'leaf_paths' filter has been deprecated for 9 years and was
  removed in jqlang v1.7 (jq v1.6) so use the 'paths(scalars)' filter.
   - c.f. https://github.com/jqlang/jq/pull/2666
   - c.f. https://github.com/jqlang/jq/pull/426
* Remove upper bound on jq version
   - Reverts https://github.com/yadage/packtivity/pull/97
```