### PR TITLE
build: Use dirhash dependency for dir hashes

### DIFF
--- a/packtivity/statecontexts/posixfs_context.py
+++ b/packtivity/statecontexts/posixfs_context.py
@@ -1,10 +1,12 @@
 import hashlib
-import os
-import shutil
 import json
 import logging
-import checksumdir
+import os
+import shutil
+
 import six
+from dirhash import dirhash
+
 import packtivity.utils as utils
 
 log = logging.getLogger(__name__)
@@ -116,12 +118,12 @@ class LocalFSState(object):
         """
         # hash the upstream / input state
         dep_checksums = [
-            checksumdir.dirhash(d) for d in self.readonly if os.path.isdir(d)
+            dirhash(d, "sha1") for d in self.readonly if os.path.isdir(d)
         ]
 
         # hash out writing state
         state_checksums = [
-            checksumdir.dirhash(d) for d in self.readwrite if os.path.isdir(d)
+            dirhash(d, "sha1") for d in self.readwrite if os.path.isdir(d)
         ]
         return hashlib.sha1(
             json.dumps([dep_checksums, state_checksums]).encode("utf-8")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ deps = [
     "jq>=1.0.0",
     "yadage-schemas",
     "mock",
-    "checksumdir",
+    "dirhash>=0.4.0",
 ]
 
 if not "READTHEDOCS" in os.environ:


### PR DESCRIPTION
Resolves #109.

* Use dirhash library over checksumdir, as dirhash is maintained and checksumdir is not.
   - c.f. https://github.com/to-mc/checksumdir
   - state_hash states it returns the SHA1 hash, so use sha1 for the algorithm.
* Apply isort.