### PR TITLE
ci: Add Python 3.12 to testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         python -m pip list
 
     - name: Lint with Pyflakes
-      if: matrix.python-version == '3.11'
+      if: matrix.python-version == '3.12'
       run: |
         python -m pyflakes packtivity
 
@@ -65,7 +65,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
* Add Python 3.12 to the CI testing matrix.
* Default to Python 3.12 in CI workflows.
* Add Python 3.12 to metadata.