### PR TITLE
docs: Add CITATION.cff Citation File Format file

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,3 +4,5 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
+
+[bumpversion:file:CITATION.cff]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+authors:
+- family-names: "Heinrich"
+  given-names: "Lukas"
+  orcid: "https://orcid.org/0000-0002-4048-7584"
+  affiliation: "Technical University of Munich"
+- family-names: "Feickert"
+  given-names: "Matthew"
+  orcid: "https://orcid.org/0000-0003-4124-7862"
+  affiliation: "University of Wisconsin-Madison"
+title: "packtivity: v0.16.2"
+version: 0.16.2
+doi: 10.5281/zenodo.309302
+repository-code: "https://github.com/yadage/packtivity/releases/tag/v0.16.2"
+url: "https://github.com/yadage/packtivity/"
+keywords:
+  - python
+  - physics
+  - yadage
+  - reinterpretation
+  - analysis reuse
+license: "Apache-2.0"
+references:
+  - type: article
+    authors:
+    - family-names: "Cranmer"
+      given-names: "Kyle"
+      orcid: "https://orcid.org/0000-0002-5769-7094"
+      affiliation: "New York University"
+    - family-names: "Heinrich"
+      given-names: "Lukas"
+      orcid: "https://orcid.org/0000-0002-4048-7584"
+      affiliation: "New York University"
+    title: "Yadage and Packtivity - analysis preservation using parametrized workflows"
+    doi: 10.1088/1742-6596/898/10/102019
+    url: "https://doi.org/10.1088/1742-6596/898/10/102019"
+    year: 2017
+    publisher:
+      name: "IOPscience"
+    volume: 898
+    pages: 102019
+    journal: "Journal of Physics: Conference Series"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup, find_packages
 from pathlib import Path
 
@@ -26,8 +25,9 @@ setup(
     long_description=(this_directory / "README.md").read_text(),
     long_description_content_type="text/markdown",
     url="https://github.com/yadage/packtivity",
-    author="Lukas Heinrich",
-    author_email="lukas.heinrich@cern.ch",
+    author = 'Lukas Heinrich, Matthew Feickert',
+    author_email = 'lukas.heinrich@gmail.com, matthew.feickert@cern.ch',
+    license="MIT",
     packages=find_packages(),
     python_requires=">=3.8",
     include_package_data=True,


### PR DESCRIPTION
* Add Citation File Format file to repo to get repository cite button on GitHub.
   - c.f. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files
* Add CITATION.cff to bump2version control.
* Add Matthew Feickert to authors.